### PR TITLE
Do not blacklist staging and dev url domains

### DIFF
--- a/drush/provision_hosting_le.drush.inc
+++ b/drush/provision_hosting_le.drush.inc
@@ -103,14 +103,6 @@ function drush_provision_hosting_le_post_provision_verify() {
       return FALSE;
     }
 
-    if (preg_match("/\.(?:host8|boa)\.(?:biz|io)$/", $main_name) ||
-        preg_match("/\.(?:dev|devel|temp|tmp|temporary)\./", $main_name) ||
-        preg_match("/\.(?:test|testing|stage|staging)\./", $main_name)
-       ) {
-      drush_log('[hosting_le] Skipping LE setup for ' . $main_name);
-      return FALSE;
-    }
-
     if (provision_file()->exists($demo_mode_ctrl)->status()) {
       if (!provision_file()->exists($le_conf)->status()) {
 


### PR DESCRIPTION
The blacklist that prevents generating a cert for dev sites does not make sense to me.

If I don't care about SSL then I won't enable it for that site...
And the current check only works on the main domain... not on any aliases.
