### PR TITLE
500 error with Apache 2.2

### DIFF
--- a/hosting_le_vhost/drush/hosting_le_vhost.drush.inc
+++ b/hosting_le_vhost/drush/hosting_le_vhost.drush.inc
@@ -108,7 +108,10 @@ function hosting_le_vhost_provision_apache_vhost_config($uri, $data) {
     $lines[] = "";
     $lines[] = "  # Allow access to letsencrypt.org ACME challenges directory.";
     $lines[] = "  <Directory \"$aegir_root/tools/le/.acme-challenges\">";
+    $lines[] = "    Order allow,deny";
+    $lines[] = "    Allow from all";
     $lines[] = "    Require all granted";
+    $lines[] = "    Satisfy Any";
     $lines[] = "  </Directory>";
     $lines[] = "\n";
 


### PR DESCRIPTION
Verifying a site under Apache 2.2 gives a server 500 error: "Configuration error: couldn't perform authentication. AuthType not set!". This happens when LE tries to access the .well-known/acme-challenge/[hash] url.

I've applied the work around from anarcat in http://stackoverflow.com/a/22180237 which makes this work in both 2.2 and 2.4 
